### PR TITLE
Add compiler requirements to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ env:
   global:
     - secure: lLh4WEpXrERVSJlpDLA0PQ+wRG4ascs3oydkiGV3VQ0G5vTrsTzrCGy3ZTt9q9L28ThKGt5n9VIKOVFahNEM9AWuim/9scXo+bCMttlWctAudw/jtxhr1vZqPw+lb+ZVsWaexv+OgoVwzY12eVP+jh1iGr7M1PcmDh8ardDyGQ0=
     - secure: DP949nTUjP1b92+Xq9JfWgaoVU7GWcWhLo6zuQpTv5Y06N6/677Z926SghysdA/OO8OYtHemPIc096oYIBKzK0Lhe772l7f/Lse81gJ78ggWaFrOGZWZ32KapWqVuOxn4OPXn8tBRPrvNN4ApB3I8gY/mfGkPfRnmOIfA2nDZrU=
+  matrix:
+    - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
I believe this is the missing configuration for ed25519-supercop

Doc: https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
